### PR TITLE
Please fix the extra `endsnippet`.

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -221,4 +221,3 @@ endsnippet
 snippet ir "isRequired" w
 isRequired,
 endsnippet
-ndsnippet


### PR DESCRIPTION
There is an extra `endsnippet` at the end, which causes UltiSnips to send out SyntaxError in nvim (and probably in vim too). Can you fix it? Or at least accept the pull-request? I will be grateful. 🙂